### PR TITLE
improved regex for imgur galleries

### DIFF
--- a/library.js
+++ b/library.js
@@ -3,7 +3,7 @@
     var Imgur = {},
         post = '<blockquote class="imgur-embed-pub" lang="en" data-id="$1"></blockquote><script async src="//s.imgur.com/min/embed.js" charset="utf-8"></script>',
         galleries = '<blockquote class="imgur-embed-pub" lang="en" data-id="a/$1"></blockquote><script async src="//s.imgur.com/min/embed.js" charset="utf-8"></script>'
-    var	embedgallery = /<a href="(?:https?:\/\/)?(?:imgur\.com)\/gallery\/?([\w\-_]+)">.+<\/a>/g;
+    var embedgallery = /<a href="(?:https?:\/\/)?(?:imgur\.com)\/(?:gallery|a)\/?([\w\-_]+)"[^>]*>[^<]+<\/a>/g;
     var	embedpost = /<a href="(?:https?:\/\/)?(?:imgur\.com)\/?([\w\-_]+)">.+<\/a>/g;
 
 

--- a/library.js
+++ b/library.js
@@ -3,8 +3,8 @@
     var Imgur = {},
         post = '<blockquote class="imgur-embed-pub" lang="en" data-id="$1"></blockquote><script async src="//s.imgur.com/min/embed.js" charset="utf-8"></script>',
         galleries = '<blockquote class="imgur-embed-pub" lang="en" data-id="a/$1"></blockquote><script async src="//s.imgur.com/min/embed.js" charset="utf-8"></script>'
-    var embedgallery = /<a href="(?:https?:\/\/)?(?:imgur\.com)\/(?:gallery|a)\/?([\w\-_]+)"[^>]*>[^<]+<\/a>/g;
-    var	embedpost = /<a href="(?:https?:\/\/)?(?:imgur\.com)\/?([\w\-_]+)">.+<\/a>/g;
+    var embedgallery = /<a href="(?:https?:\/\/)?(?:imgur\.com)\/(?:gallery|a)\/?([\w\-_]+)(#[^"]*)?"[^>]*>[^<]+<\/a>/g;
+    var	embedpost = /<a href="(?:https?:\/\/)?(?:imgur\.com)\/?([\w\-_]+)(#[^"]*)?">.+<\/a>/g;
 
 
     Imgur.parse = function(data, callback) {


### PR DESCRIPTION
- support `/a/` , not only `/gallery/`
- match also if `<a>` contains more attributes than just `href`
- dont be too greedy when matching link text


*edit: due to inactivity on the author's part, I decided to re-publish under `nodebb-plugin-embed-imgur-2`*